### PR TITLE
Refactor as an attempt to remedy two codebeat failed checks, and misc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serialize-anything",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "serialize and de-serialize any JavaScript data",
   "main": "index.js",
   "repository": {

--- a/test/result-serialize-anything.txt
+++ b/test/result-serialize-anything.txt
@@ -1,15 +1,15 @@
 
 Test1 (Date):
   const src = new Date();
-    src:   2022-07-14T04:51:53.959Z
+    src:   2022-07-19T05:16:19.339Z
     ser:  '{
   "_Serialize_Any_Encoded": true,
   "_SA_Content": {
     "_SAType": "Date",
-    "_SAtimestamp": 1657774313959
+    "_SAtimestamp": 1658207779339
   }
 }'
-    deser: Date: Wed Jul 13 2022 21:51:53 GMT-0700 (Pacific Daylight Time)
+    deser: Date: Mon Jul 18 2022 22:16:19 GMT-0700 (Pacific Daylight Time)
 
 Test2 (Map):
   let src = new Map();
@@ -19,7 +19,7 @@ Test2 (Map):
   src.set(key2, new Date());
     src:   Map(2) {
   'key1' => 'key1 value',
-  { foo: 'bar' } => 2022-07-14T04:51:53.967Z
+  { foo: 'bar' } => 2022-07-19T05:16:19.350Z
 }
     ser:  '{
   "_Serialize_Any_Encoded": true,
@@ -36,7 +36,7 @@ Test2 (Map):
         },
         {
           "_SAType": "Date",
-          "_SAtimestamp": 1657774313967
+          "_SAtimestamp": 1658207779350
         }
       ]
     ]
@@ -44,7 +44,7 @@ Test2 (Map):
 }'
     deser: Map(2) {
   'key1' => 'key1 value',
-  { foo: 'bar' } => 2022-07-14T04:51:53.967Z
+  { foo: 'bar' } => 2022-07-19T05:16:19.350Z
 }
 
 Test3 (Function):
@@ -258,7 +258,7 @@ Test15 (ArrayBuffer):
 
 Test16 (Set):
   let src = new Set([1,2,"3",{createdAt: new Date()}]);
-    src:  Set(4) { 1, 2, '3', { createdAt: 2022-07-14T04:51:53.977Z } }
+    src:  Set(4) { 1, 2, '3', { createdAt: 2022-07-19T05:16:19.360Z } }
     ser:  '{
   "_Serialize_Any_Encoded": true,
   "_SA_Content": {
@@ -270,14 +270,14 @@ Test16 (Set):
       {
         "createdAt": {
           "_SAType": "Date",
-          "_SAtimestamp": 1657774313977
+          "_SAtimestamp": 1658207779360
         },
         "_SAId": 2
       }
     ]
   }
 }'
-    deser: Set(4) { 1, 2, '3', { createdAt: 2022-07-14T04:51:53.977Z } }
+    deser: Set(4) { 1, 2, '3', { createdAt: 2022-07-19T05:16:19.360Z } }
 
 Test17 (WeakSet):
   let src = new WeakSet();
@@ -439,12 +439,15 @@ Test26 (demo):
     const custom = new CustomObj();
     Object.assign(custom,{foo:"bar"});
     let src = {
+      undef: undefined,
+      regexp: /abc/gi
+      bignum: 4000000000000000000n
       map: new Map([
         [1, 'one'],
-        [2, 'two'],
-        [3, 'three'],
+        [2, 'two']
       ]),
       custom
+      buffer: Buffer.from('hello world')
     };
 
     src:  {
@@ -484,16 +487,28 @@ Test26 (demo):
       ]
     },
     "custom": {
-      "_SAType": "_SACustomObject",
-      "_SAconstructorName": "CustomObj",
-      "_SAobject": {
-        "foo": "bar",
-        "_SAId": 3
+      "foo": "bar",
+      "_SAId": 3,
+      "buffer": {
+        "_SAType": "Buffer",
+        "_SAutf8String": "hello world"
       }
     },
     "buffer": {
-      "_SAType": "Buffer",
-      "_SAutf8String": "hello world"
+      "type": "Buffer",
+      "data": [
+        104,
+        101,
+        108,
+        108,
+        111,
+        32,
+        119,
+        111,
+        114,
+        108,
+        100
+      ]
     },
     "_SAId": 1
   }
@@ -503,8 +518,15 @@ Test26 (demo):
   regexp: /abc/gi,
   bignum: 4000000000000000000n,
   map: Map(2) { 1 => 'one', 2 => 'two' },
-  custom: CustomObj { foo: 'bar' },
-  buffer: <Buffer 68 65 6c 6c 6f 20 77 6f 72 6c 64>
+  custom: { foo: 'bar', buffer: <Buffer 68 65 6c 6c 6f 20 77 6f 72 6c 64> },
+  buffer: {
+    type: 'Buffer',
+    data: [
+      104, 101, 108, 108,
+      111,  32, 119, 111,
+      114, 108, 100
+    ]
+  }
 }
 
 Test27 (circular object reference):

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -642,12 +642,15 @@ function test26 (serialize, deserialize, options) {
     '    const custom = new CustomObj();\n' +
     '    Object.assign(custom,{foo:"bar"});\n' +
     '    let src = {\n' +
+    '      undef: undefined,\n' +
+    '      regexp: /abc/gi\n' +
+    '      bignum: 4000000000000000000n\n' +
     '      map: new Map([\n' +
     '        [1, \'one\'],\n' +
-    '        [2, \'two\'],\n' +
-    '        [3, \'three\'],\n' +
+    '        [2, \'two\']\n' +
     '      ]),\n' +
     '      custom\n' +
+    '      buffer: Buffer.from(\'hello world\')\n' +
     '    };\n'
   );
   try {
@@ -667,6 +670,7 @@ function test26 (serialize, deserialize, options) {
     console.log(`    ser:  '${ser}'`);
     let deser = deserialize(ser);
     console.log('    deser:', deser);
+    if (deser.map.get(1) != 'one') throw new Error('Map does not contain right value for key, "1"');
   } catch (err) {
     console.log('*** TEST FAILED:', err);
     errors.push('Test26 ' + err.toString());


### PR DESCRIPTION
1. Refactor as an attempt to remedy two codebeat failed checks by breaking up serializeObject() into two functions:
  a. serializeObject()
  b. serializeElement() - helper
2. Added test to ensure Map is correctly serialized / deserialized
3. Remedy other discrepencies between tests' logged and actual source objects.